### PR TITLE
[Tournament] Allow a captain to edit his team's name and password

### DIFF
--- a/src/InsaLan/TournamentBundle/Resources/views/User/editTeam.html.twig
+++ b/src/InsaLan/TournamentBundle/Resources/views/User/editTeam.html.twig
@@ -1,0 +1,52 @@
+{% extends 'InsaLanTournamentBundle:User:layout.html.twig' %}
+
+{% block body %}
+{{ parent() }}
+
+<article>
+  <aside>
+    <div class="square">
+      <a href="#body"><span></span></a>
+    </div>
+  </aside>
+
+  <header>
+    <h2>Inscription à &laquo; {{ tournament.name }} &raquo;</h2>
+    {{ tournament.description }}
+  </header>
+
+  <section>
+
+    <div class="frame frame-active">
+      <header class="full">
+        <div class="step pull-left">&#x2699;</div>
+        <div class="title pull-left">Modifier une équipe</div>
+        <br class="clear">
+      </header>
+
+        <form action="{{ path('insalan_tournament_user_editteam', {teamId: team.id}) }}" id="step1" method="post" {{ form_enctype(form) }}>
+
+          {{ form_widget(form._token) }}
+          {{ form_errors(form) }}
+
+          <div class="input field">
+            {{ form_widget(form.name, {'attr': {'placeholder': 'Nom de votre équipe'}}) }}
+          </div>
+
+          <div class="input field">
+            {{ form_widget(form.plainPassword.first, {'attr': {'placeholder': 'Nouveau mot de passe (Laissez vide pour ne pas modifier)'}}) }}
+          </div>
+
+          <div class="input field">
+            {{ form_widget(form.plainPassword.second, {'attr': {'placeholder': 'Confirmation de mot de passe'}}) }}
+          </div>
+
+          <a class="btn btn-danger ctrl grid-2 pull-left" href="{{ path('insalan_tournament_user_index') }}">Annuler</a>
+          <a class="btn btn-primary ctrl grid-8 pull-left" href="javascript:{}" onclick="document.getElementById('step1').submit();">Modifier mon équipe</a>
+          <br class="clear">
+        </form>
+    </div>
+
+  </section>
+</article>
+{% endblock %}

--- a/src/InsaLan/TournamentBundle/Resources/views/User/index.html.twig
+++ b/src/InsaLan/TournamentBundle/Resources/views/User/index.html.twig
@@ -17,6 +17,9 @@
         {% if participant.validated == 2 %} &#10003; {% else %} ! {% endif %}
       </div>
       <div class="title pull-left">
+        {% if participant.participantType == 'team' %}
+          {% if participant.captain.user == app.user %} <a href="{{ path('insalan_tournament_user_editteam', {teamId: participant.id}) }}">&#x2699;</a> {% endif %}
+        {% endif %}
         {{ participant.tournament.name }} - 
         {% if participant.participantType == 'team' %} Équipe {% endif %}
         {{ participant.name }}


### PR DESCRIPTION
 (part of #33)

Not sure about the button appearance & location.
![capture d ecran de 2016-08-17 01-25-16](https://cloud.githubusercontent.com/assets/505052/17719451/e09c4ca2-641a-11e6-941a-c32306d3a7cc.png)

Also, should we forbid the change when the team is validated or when the tournament begins ?
