### PR TITLE
Use PHP7 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,20 @@ php:
   - 7.2.6
 
 before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+
+script:
   - cp app/config/parameters.yml.travis app/config/parameters.yml
   - composer install
   - php app/console doctrine:database:create --env=test
   - php app/console doctrine:schema:create --env=test
   - php app/console doctrine:fixtures:load -n --env=test
-
-script:
   - phpunit -c app/
 
 after_script:
-  - ./vendor/codeclimate/php-test-reporter/composer/bin/test-reporter --coverage-report app/build/logs/clover.xml
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: php
 php:
-  - 5.5
+  - 7.2.6
 
 before_script:
   - cp app/config/parameters.yml.travis app/config/parameters.yml

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ insalan.fr
 ==========
 
 [![Build Status](https://travis-ci.org/InsaLan/insalan.fr.svg?branch=master)](https://travis-ci.org/InsaLan/insalan.fr)
-[![Code Climate](https://codeclimate.com/github/superboum/insalan.fr/badges/gpa.svg)](https://codeclimate.com/github/superboum/insalan.fr)
-[![Test Coverage](https://codeclimate.com/github/superboum/insalan.fr/badges/coverage.svg)](https://codeclimate.com/github/superboum/insalan.fr)
+[![Maintainability](https://api.codeclimate.com/v1/badges/68707ca6cd1a2b332dc4/maintainability)](https://codeclimate.com/github/InsaLan/insalan.fr/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/68707ca6cd1a2b332dc4/test_coverage)](https://codeclimate.com/github/InsaLan/insalan.fr/test_coverage)
 
 Website to handle esport tournament
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 insalan.fr
 ==========
 
+[![Build Status](https://travis-ci.org/InsaLan/insalan.fr.svg?branch=master)](https://travis-ci.org/InsaLan/insalan.fr)
 [![Code Climate](https://codeclimate.com/github/superboum/insalan.fr/badges/gpa.svg)](https://codeclimate.com/github/superboum/insalan.fr)
 [![Test Coverage](https://codeclimate.com/github/superboum/insalan.fr/badges/coverage.svg)](https://codeclimate.com/github/superboum/insalan.fr)
 


### PR DESCRIPTION
Fix Travis to finally use a CI and run your unit tests automatically :)
You should also add your email addresses to the `.travis.yml` file to be notified of failed builds...