### PR TITLE
Remove Maximilien's and my email from Travis notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,4 @@ after_script:
 
 notifications:
   email:
-    -  quentin@dufour.io
-    -  mricher@insa-rennes.fr
     -  abourven@insa-rennes.fr


### PR DESCRIPTION
I am not actively contributing to insalan.fr anymore so it doesn't make much sense to keep receiving Travis notifications. Moreover, mricher `at` insa-rennes.fr has been closed as Maximilien graduated more than one year ago, there is no reason to keep this address too.